### PR TITLE
Bug.  Plaintext Message is reset to all 0s in secretbox_open

### DIFF
--- a/pure_pynacl/tweetnacl.py
+++ b/pure_pynacl/tweetnacl.py
@@ -263,7 +263,7 @@ def crypto_onetimeauth_poly1305_tweet(out, m, n, k):
     r[15] &= 15
 
     while n > 0:
-        c[:] = 17*[u32()]
+        c[:17] = 17*[u32()]
         for j in range(16):
             if j >= n: j -= 1 ; break
             c[j] = m[j]
@@ -332,7 +332,7 @@ def crypto_secretbox_xsalsa20poly1305_tweet_open(m, c, d, n, k):
     crypto_stream_xsalsa20_tweet(x, 32, n, k)
     if crypto_onetimeauth_poly1305_tweet_verify(c[16:], c[32:], d - 32, x) != 0: return -1
     crypto_stream_xsalsa20_tweet_xor(m, c, d, n, k)
-    m[:] = 32*[u8()]
+    m[:32] = 32*[u8()]
     return 0
 
 


### PR DESCRIPTION
The entire plaintext message is reset to all 0s in secretbox_open.  This is not what is desired.  Only the first part of the message array should be reset to zeros.  See https://github.com/dominictarr/tweetnacl/blob/master/tweetnacl.c#L263

The same error occurred (copy-paste error?) in other functions 
https://github.com/dominictarr/tweetnacl/blob/master/tweetnacl.c#L200